### PR TITLE
Fix player sneakjump in twilight

### DIFF
--- a/mods/twilight/init.lua
+++ b/mods/twilight/init.lua
@@ -210,7 +210,7 @@ else
 		jump = 1.0, -- multiplier to default value
 		gravity = 1.0, -- multiplier to default value
 		sneak = true, -- whether player can sneak
-		sneak_glitch = false, -- whether player can use the sneak glitch 
+		sneak_glitch = true, -- whether player can use the sneak glitch
 
 		})
 	end


### PR DESCRIPTION
Fix a bug that caused the player to not be able to sneakjump after exiting twilight mode.