### PR TITLE
Fix steel boomerang name in loot mod

### DIFF
--- a/mods/dungeon_loot/init.lua
+++ b/mods/dungeon_loot/init.lua
@@ -28,7 +28,7 @@ local chest_stuff = {
 	{name="maptools:nyan_coin", max = 5},
 	{name="twilight:crystal", max = 1},
 	{name="hyruletools:triforce_shard", max = 1},
-	{name="hyruletools:steel_boomerang", max = 1},
+	{name="hyruletools:boomerang_steel", max = 1},
 	{name="default:ice", max = 3}
 }
 


### PR DESCRIPTION
Fix the naming of the Steel Boomerang in the dungeon loot mod.